### PR TITLE
[update] Webインターフェースからのキャプチャコマンド発行，安全なプロセスキルに成功

### DIFF
--- a/webapp/ghostwriter/management/commands/capture.py
+++ b/webapp/ghostwriter/management/commands/capture.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
-import os
 from django.core.management.base import BaseCommand
-from django.conf import settings
 from slidecapture import SlideCapture, SlideCaptureError
 
 
@@ -10,7 +8,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         try:
-            with SlideCapture(1) as cap:
+            with SlideCapture(0) as cap:
                 cap.monitor_slides("media/cache")
         except SlideCaptureError:
-            pass
+            print("Couldn't open camera!!")

--- a/webapp/ghostwriter/management/commands/capture_test.py
+++ b/webapp/ghostwriter/management/commands/capture_test.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+from django.core.management.base import BaseCommand
+from datetime import datetime
+from time import sleep
+
+
+class PersistentProcess(object):
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        print("PROCESS END")
+        return True
+
+    def run(self):
+        while True:
+            print(datetime.now())
+            sleep(30)
+
+
+class Command(BaseCommand):
+    help = "Test command for asynchronous capture"
+
+    def handle(self, *args, **options):
+        with PersistentProcess() as p:
+            p.run()

--- a/webapp/ghostwriter/tasks.py
+++ b/webapp/ghostwriter/tasks.py
@@ -90,6 +90,12 @@ def get_ocr_text(self, lecture_id: int, new_image_id: list):
         lecture.save()
 
 
+@task
+def empty_task():
+    from time import sleep
+    sleep(10)
+
+
 def on_task_revoked(*args, **kwargs):
     print(str(kwargs))
     print('task_revoked')

--- a/webapp/ghostwriter/views.py
+++ b/webapp/ghostwriter/views.py
@@ -1,12 +1,12 @@
 import os
+from subprocess import Popen
 from django.views.generic import TemplateView, ListView, CreateView
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.conf import settings
-from .models import Image, Lecture, TaskRecord
+from .models import Image, Lecture, TaskRecord, TaskState, TaskType
 from .forms import LectureForm, LectureImageRelForm
-from .capture_lib import SlideCapture, SlideCaptureError
-from .tasks import get_ocr_text
+from .tasks import get_ocr_text, empty_task
 
 
 class IndexView(TemplateView):
@@ -66,20 +66,15 @@ class CameraCalibration(TemplateView):
     template_name = "ghostwriter/calibrate.html"
 
     def post(self, request, *args, **kwards):
-        if request.POST.get('force_delete', None):
-            from celery.task.control import revoke
-            task = TaskRecord.objects.filter(type=1).filter(state=0).first()
-            if task:
-                revoke(task.task_id, terminate=True)
-            return redirect("ghostwriter:tasks")
-        from .tasks import register_image
-        # 画像登録タスク
-        register_image_record = TaskRecord()
-        register_id = register_image.delay().id
-        register_image_record.task_id = register_id
-        register_image_record.state = 0
-        register_image_record.type = 1
-        register_image_record.save()
+        task_id = empty_task.delay().id
+        TaskRecord.objects.create(
+            state=TaskState.RUNNING.value,
+            type=TaskType.CAPTURE.value,
+            task_id=task_id
+        )
+        p = Popen("python manage.py capture", shell=True, close_fds=False)
+        with open("process.pid", "w") as fp:
+            fp.write(str(p.pid))
         return redirect("ghostwriter:tasks")
 
 
@@ -90,3 +85,19 @@ class TaskView(TemplateView):
         context = super(TaskView, self).get_context_data(**kwargs)
         context["tasks"] = TaskRecord.objects.all().order_by('-id')
         return context
+
+    def post(self, request, *args, **kwards):
+        task_id = request.POST.get("task_id")
+        task_record = TaskRecord.objects.get(task_id=task_id)
+        try:
+            with open("process.pid", "r") as fp:
+                from signal import SIGINT
+                pid = fp.read()
+            os.kill(int(pid), SIGINT)
+            task_record.state = TaskState.DONE.value
+            return redirect('ghostwriter:index')
+        except Exception:
+            task_record.state = TaskState.FAIL.value
+            return redirect('ghostwriter:tasks')
+        finally:
+            task_record.save()

--- a/webapp/templates/ghostwriter/calibrate.html
+++ b/webapp/templates/ghostwriter/calibrate.html
@@ -16,15 +16,18 @@
                     <a class="btn btn-primary" href="{% url 'ghostwriter:index' %}">戻る</a>
                     {% else %}
                     <h2>キャリブレーション</h2>
-                        <div>
-                            <select id="select">
+                        <form method="post" class="form-group">
+                            {% csrf_token %}
+                            <label for="select_camera_id">カメラ</label>
+                            <select id="select_camera_id" class="form-control" name="select_camera_id">
                                 <option value="">カメラを選択してください</option>
                             </select>
                             <div>
                                 <video id="video"></video>
                             </div>
-                        </div>
-                        <a class="btn btn-primary" href="{% url 'ghostwriter:index' %}">戻る</a>
+                            <a class="btn btn-primary" href="{% url 'ghostwriter:index' %}">戻る</a>
+                            <button class="btn btn-primary" type="submit" value="submit">Capture Start</button>
+                        </form>
                     {% endif %}
                 </div>
             </div>
@@ -56,10 +59,11 @@
              * カメラを選択するセレクトボックスを組み立てる
              */
             function render(videoSroucesArray) {
-                var $selectBox = document.querySelector('#select')
+                var $selectBox = document.querySelector('#select_camera_id')
                 videoSroucesArray.forEach(function (source, idx) {
+                    console.log(source);
                     var label = source.label !== "" ? source.label : ("カメラ" + idx);
-                    $selectBox.insertAdjacentHTML("beforeend", "<option value='" + source.deviceId + "'>" + label + "</option>");
+                    $selectBox.insertAdjacentHTML("beforeend", "<option value='" + idx + "'>" + label + "</option>");
                 });
                 return this;
             }
@@ -100,7 +104,7 @@
                 })
             }
 
-            var selectBox = document.querySelector('#select');
+            var selectBox = document.querySelector('#select_camera_id');
             selectBox.addEventListener('change', start, false);
         };
     </script>

--- a/webapp/templates/ghostwriter/task_abstract.html
+++ b/webapp/templates/ghostwriter/task_abstract.html
@@ -14,6 +14,11 @@
                             <p class="list-group-item-text">ID: {{ task.task_id }}</p>
                             {% if task.state == 0 %}
                                 <span class="label label-info">{{ task.get_state_display }}</span>
+                                <form method="post" class="form-group">
+                                    {% csrf_token %}
+                                    <input type="hidden" value="{{ task.task_id }}" name="task_id">
+                                    <button class="btn btn-primary" type="submit" value="submit">Stop</button>
+                                </form>
                             {% else %}
                                 <span class="label label-danger">{{ task.get_state_display }}</span>
                             {% endif %}


### PR DESCRIPTION
refs #106

以下の様な処理を行っている

1. `cariblate`ページから`Capture Start`ボタンをクリックでPostリクエスト送信
2. `ghostwriter.views.CameraCalibration`クラスがPostリクエストを受け，空のceleryタスクを発行（一意な名前取得のため）
3. `subprocess.Popen`を使って`python manage.py capture`をシェル経由で実行し，**終了を待たずに**pidを直下に`process.pid`として保存してTask一覧ページへのリダイレクトを返す
4. Taskページの`RUNNING`なタスクには`STOP`ボタンが置かれるので，キャプチャが終了したらそれを押すとPostリクエストが送信される
5. `ghostwriter.views.TaskView`クラスがPostリクエストを受け，送信されたtask idに基づいて`Task Record`オブジェクトを取得
6. `process.pid`を読み込み，`os.kill(pid, signal.SIGINT)`で`python manage.py capture`を実行中のプロセスを終了させる（ここで`SlideCapture`の`__exit__`が呼ばれカメラリソースが解放される）
7. 正常に終了できれば`TaskRecord.state`を`DONE`にしトップページへのリダイレクトを返す．エラーが起きれば`FAIL`にし，Task一覧へリダイレクトする．

この後取得した画像の登録プロセスを走らせる必要があるが，まずここまでで一度区切り．